### PR TITLE
feat!: harden security posture and expose composition outputs (v4.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,62 @@
 # AWS Bastion Server
 
-This module creates an AWS EC2 Instance with a given AMI to be used as a bastion server. Multiple inputs are available to allow access to existing security groups as well as restricting SSH access by network CIDR.
+Reusable Terraform module for a minimal SSH jump host — an EC2 instance in a public subnet, intended purely as a network hop into private resources (RDS, private-subnet services, etc.).
+
+The module is opinionated on security posture: SSH ingress is restricted by caller-supplied CIDR (no public-internet default), IMDSv2 is required, the root volume is encrypted, and the instance is granted the SSM Session Manager managed policy as a break-glass fallback.
+
+## Usage
+
+```hcl
+module "bastion" {
+  source  = "git::https://github.com/synapsestudios/terraform-aws-bastion-server.git?ref=v4.0.0"
+
+  namespace   = "prod-myapp"
+  environment = "prod"
+  vpc_id      = module.vpc.vpc_id
+  subnet_id   = module.vpc.public_subnets[0]
+
+  # Required — module does not default to 0.0.0.0/0.
+  allowed_cidr_blocks = ["203.0.113.42/32"]
+
+  # Optional — pin AMI to avoid plan-time replacement every time
+  # Amazon publishes a new AL2023 image. When omitted the module resolves
+  # the latest AL2023 via a data source.
+  ami_id = "ami-0123456789abcdef0"
+
+  tags = { ApplicationName = "myapp" }
+}
+
+# Cross-resource rules (e.g. letting the bastion reach a database SG) are
+# the composing root module's responsibility. Reference `module.bastion.security_group_id`
+# and attach them where both sides of the relationship are visible.
+resource "aws_security_group_rule" "bastion_to_db" {
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = module.bastion.security_group_id
+  security_group_id        = module.aurora.security_group_id
+  description              = "PostgreSQL access from bastion"
+}
+```
+
+## Connecting
+
+Retrieve the SSH key from Secrets Manager, then either SSH directly or open a tunnel:
+
+```bash
+aws secretsmanager get-secret-value \
+  --secret-id "$(terraform output -raw ssh_key_name)" \
+  --query SecretString --output text > ~/.ssh/bastion.pem
+chmod 600 ~/.ssh/bastion.pem
+
+# Tunnel for a Postgres client talking to a private-subnet Aurora cluster:
+ssh -i ~/.ssh/bastion.pem \
+    -L 5432:<aurora-endpoint>:5432 \
+    ec2-user@$(terraform output -raw public_ip)
+```
+
+For emergency access when the SSH key is unavailable, the instance is enrolled in SSM Session Manager — `aws ssm start-session --target <instance-id>` works without opening port 22.
 
 ## Running tests
 
@@ -18,8 +74,7 @@ Per the Synapse doc, E2E and Environment-E2E levels apply to root-module repos (
 terraform init -test-directory=tests/unit
 terraform test -test-directory=tests/unit
 
-# Integration — requires AWS credentials (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION)
-# Provisions real infra, asserts on shape/state, SSHes to the bastion, and tears everything down.
+# Integration — requires AWS credentials
 terraform init -test-directory=tests/integration
 terraform test -test-directory=tests/integration
 ```
@@ -47,20 +102,26 @@ The shared `tests/setup/` helper module provisions a minimal VPC + public subnet
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| namespace | Determines naming convention of assets. Generally follows DNS naming convention. | `string` | n/a | yes |
+| allowed\_cidr\_blocks | CIDR blocks permitted to reach the bastion on port 22. | `list(string)` | n/a | yes |
 | environment | Deployment environment tag value (e.g. dev, uat, prod, shared). Applied to every resource created by this module. | `string` | n/a | yes |
+| namespace | Determines naming convention of assets. Generally follows DNS naming convention. | `string` | n/a | yes |
 | subnet\_id | ID of subnet to deploy bastion server on. | `string` | n/a | yes |
 | tags | A mapping of tags to assign to the AWS resources. | `map(string)` | n/a | yes |
 | vpc\_id | ID of the VPC to deploy bastion server on. | `string` | n/a | yes |
+| ami\_id | (Optional) Explicit AMI ID to launch the bastion with. When null, the latest Amazon Linux 2023 AMI is used. | `string` | `null` | no |
 | instance\_type | (Optional) EC2 Instance type to provision. | `string` | `"t3.micro"` | no |
-| volume\_size | (Optional) The size of the volume in gibibytes (Default 15 GiB). | `number` | `15` | no |
-| volume\_type | (Optional) The type of volume. Can be 'standard', 'gp2', 'io1', 'sc1', or 'st1'. (Default: 'gp2'). | `string` | `"gp2"` | no |
+| volume\_size | (Optional) The size of the volume in gibibytes. | `number` | `30` | no |
+| volume\_type | (Optional) The type of volume. Can be 'standard', 'gp2', 'gp3', 'io1', 'sc1', or 'st1'. | `string` | `"gp3"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| instance\_id | EC2 instance ID of the bastion server |
 | public\_ip | The public IP address associated with this Bastion server |
-| ssh\_key\_name | The name of the Secrets Manager key for the bastion server's ssh key |
+| security\_group\_id | Security group ID of the bastion |
+| ssh\_key\_name | The name of the Secrets Manager secret containing the bastion's SSH private key |
+| ssh\_key\_secret\_arn | ARN of the Secrets Manager secret containing the bastion's SSH private key |
+| ssh\_private\_key\_pem | The bastion's SSH private key in PEM format. Sensitive. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,16 @@
-data "aws_ami" "amazon-linux-2" {
+data "aws_ami" "amazon_linux_2023" {
+  count       = var.ami_id == null ? 1 : 0
   owners      = ["amazon"]
   most_recent = true
 
   filter {
     name   = "name"
-    values = ["amzn2-ami-hvm-*-x86_64-ebs"]
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
   }
 }
 
@@ -15,6 +21,8 @@ locals {
     Module        = "terraform-aws-bastion-server"
     ModuleVersion = "local"
   }
+
+  ami_id = var.ami_id != null ? var.ami_id : data.aws_ami.amazon_linux_2023[0].id
 }
 
 resource "tls_private_key" "key" {
@@ -39,7 +47,7 @@ resource "aws_secretsmanager_secret_version" "this" {
 }
 
 resource "aws_instance" "this" {
-  ami                         = data.aws_ami.amazon-linux-2.id
+  ami                         = local.ami_id
   associate_public_ip_address = true
   iam_instance_profile        = aws_iam_instance_profile.this.name
   instance_type               = var.instance_type
@@ -52,6 +60,13 @@ resource "aws_instance" "this" {
     encrypted   = true
     volume_type = var.volume_type
     volume_size = var.volume_size
+  }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+    instance_metadata_tags      = "enabled"
   }
 }
 
@@ -70,8 +85,8 @@ resource "aws_security_group" "this" {
     from_port   = 22
     to_port     = 22
     protocol    = 6
-    cidr_blocks = ["0.0.0.0/0"]
-    description = "Allow incoming SSH connections."
+    cidr_blocks = var.allowed_cidr_blocks
+    description = "Allow SSH from authorized CIDRs."
   }
 
   egress {
@@ -101,6 +116,11 @@ resource "aws_iam_role" "this" {
   })
 
   tags = merge(local.default_tags, var.tags)
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.this.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
 resource "aws_iam_instance_profile" "this" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,8 +3,28 @@ output "public_ip" {
   value       = aws_eip.lb.public_ip
 }
 
-# Output the secret name for the ssh key
+output "instance_id" {
+  description = "EC2 instance ID of the bastion server"
+  value       = aws_instance.this.id
+}
+
+output "security_group_id" {
+  description = "Security group ID of the bastion. Consumers that need to permit traffic from the bastion to another resource (e.g. a database) should reference this and create the target-side ingress rule in their own root module, keeping cross-resource rule ownership out of this module."
+  value       = aws_security_group.this.id
+}
+
 output "ssh_key_name" {
-  description = "The name of the Secrets Manager key for the bastion server's ssh key"
+  description = "The name of the Secrets Manager secret containing the bastion's SSH private key"
   value       = aws_secretsmanager_secret.this.name
+}
+
+output "ssh_key_secret_arn" {
+  description = "ARN of the Secrets Manager secret containing the bastion's SSH private key"
+  value       = aws_secretsmanager_secret.this.arn
+}
+
+output "ssh_private_key_pem" {
+  description = "The bastion's SSH private key in PEM format. Sensitive."
+  value       = tls_private_key.key.private_key_pem
+  sensitive   = true
 }

--- a/tests/integration/bastion.tftest.hcl
+++ b/tests/integration/bastion.tftest.hcl
@@ -2,10 +2,6 @@ variables {
   namespace   = "bastion-integ"
   environment = "test"
   tags        = { ApplicationName = "bastion-integration" }
-  # Integration harness runs from CI with an unknown egress IP, so the SSH
-  # reachability probe needs an open window. This is test-only — production
-  # callers must supply a restricted CIDR list.
-  allowed_cidr_blocks = ["0.0.0.0/0"]
 }
 
 run "setup" {
@@ -19,8 +15,9 @@ run "setup" {
 
 run "apply_bastion" {
   variables {
-    vpc_id    = run.setup.vpc_id
-    subnet_id = run.setup.public_subnet_id
+    vpc_id              = run.setup.vpc_id
+    subnet_id           = run.setup.public_subnet_id
+    allowed_cidr_blocks = [run.setup.runner_ingress_cidr]
   }
 
   assert {
@@ -36,8 +33,9 @@ run "apply_bastion" {
 
 run "eip_associated" {
   variables {
-    vpc_id    = run.setup.vpc_id
-    subnet_id = run.setup.public_subnet_id
+    vpc_id              = run.setup.vpc_id
+    subnet_id           = run.setup.public_subnet_id
+    allowed_cidr_blocks = [run.setup.runner_ingress_cidr]
   }
 
   assert {
@@ -53,8 +51,9 @@ run "eip_associated" {
 
 run "secret_version_written" {
   variables {
-    vpc_id    = run.setup.vpc_id
-    subnet_id = run.setup.public_subnet_id
+    vpc_id              = run.setup.vpc_id
+    subnet_id           = run.setup.public_subnet_id
+    allowed_cidr_blocks = [run.setup.runner_ingress_cidr]
   }
 
   assert {

--- a/tests/integration/bastion.tftest.hcl
+++ b/tests/integration/bastion.tftest.hcl
@@ -2,6 +2,10 @@ variables {
   namespace   = "bastion-integ"
   environment = "test"
   tags        = { ApplicationName = "bastion-integration" }
+  # Integration harness runs from CI with an unknown egress IP, so the SSH
+  # reachability probe needs an open window. This is test-only — production
+  # callers must supply a restricted CIDR list.
+  allowed_cidr_blocks = ["0.0.0.0/0"]
 }
 
 run "setup" {

--- a/tests/setup/main.tf
+++ b/tests/setup/main.tf
@@ -1,3 +1,10 @@
+terraform {
+  required_providers {
+    aws  = { source = "hashicorp/aws", version = "~> 5.0" }
+    http = { source = "hashicorp/http", version = "~> 3.0" }
+  }
+}
+
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 5.0"
@@ -12,4 +19,10 @@ module "vpc" {
   enable_nat_gateway   = false
   enable_dns_hostnames = true
   enable_dns_support   = true
+}
+
+# Discover the test runner's egress IP so the integration lane can scope SSH
+# ingress to that single /32 instead of punching 0.0.0.0/0 into the SG.
+data "http" "runner_ip" {
+  url = "https://checkip.amazonaws.com/"
 }

--- a/tests/setup/outputs.tf
+++ b/tests/setup/outputs.tf
@@ -5,3 +5,8 @@ output "vpc_id" {
 output "public_subnet_id" {
   value = module.vpc.public_subnets[0]
 }
+
+output "runner_ingress_cidr" {
+  description = "The test runner's public IP as a /32 CIDR, suitable for scoping SSH ingress on the bastion under test."
+  value       = "${trimspace(data.http.runner_ip.response_body)}/32"
+}

--- a/tests/unit/module.tftest.hcl
+++ b/tests/unit/module.tftest.hcl
@@ -1,11 +1,12 @@
 mock_provider "aws" {}
 
 variables {
-  namespace   = "bastion-unit"
-  environment = "test"
-  vpc_id      = "vpc-12345678"
-  subnet_id   = "subnet-12345678"
-  tags        = { ApplicationName = "unit-test" }
+  namespace           = "bastion-unit"
+  environment         = "test"
+  vpc_id              = "vpc-12345678"
+  subnet_id           = "subnet-12345678"
+  tags                = { ApplicationName = "unit-test" }
+  allowed_cidr_blocks = ["203.0.113.0/24"]
 }
 
 run "naming_conventions" {
@@ -79,6 +80,43 @@ run "sg_ingress_ssh_only" {
   }
 }
 
+run "sg_ingress_cidrs_from_variable" {
+  command = plan
+
+  assert {
+    condition     = tolist(tolist(aws_security_group.this.ingress)[0].cidr_blocks) == var.allowed_cidr_blocks
+    error_message = "Ingress cidr_blocks should come from var.allowed_cidr_blocks, not a module default"
+  }
+}
+
+run "imdsv2_required" {
+  command = plan
+
+  assert {
+    condition     = aws_instance.this.metadata_options[0].http_tokens == "required"
+    error_message = "IMDSv2 must be required (http_tokens = required)"
+  }
+
+  assert {
+    condition     = aws_instance.this.metadata_options[0].http_put_response_hop_limit == 1
+    error_message = "Metadata hop limit should be 1"
+  }
+}
+
+run "ssm_policy_attached" {
+  command = plan
+
+  assert {
+    condition     = aws_iam_role_policy_attachment.ssm.policy_arn == "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+    error_message = "Bastion IAM role must have AmazonSSMManagedInstanceCore attached for Session Manager fallback"
+  }
+
+  assert {
+    condition     = aws_iam_role_policy_attachment.ssm.role == aws_iam_role.this.name
+    error_message = "SSM policy attachment must target the bastion's IAM role"
+  }
+}
+
 run "instance_profile_wiring" {
   command = plan
 
@@ -104,6 +142,18 @@ run "eip_attached" {
   assert {
     condition     = aws_eip.lb.domain == "vpc"
     error_message = "EIP domain should be vpc"
+  }
+}
+
+run "ami_override_used_when_set" {
+  command = plan
+  variables {
+    ami_id = "ami-0123456789abcdef0"
+  }
+
+  assert {
+    condition     = aws_instance.this.ami == "ami-0123456789abcdef0"
+    error_message = "When ami_id is set, the instance should launch from that AMI rather than the data source"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,13 +1,13 @@
 variable "volume_size" {
   type        = number
-  description = "(Optional) The size of the volume in gibibytes (Default 15 GiB)."
-  default     = 15
+  description = "(Optional) The size of the volume in gibibytes."
+  default     = 30
 }
 
 variable "volume_type" {
   type        = string
-  description = "(Optional) The type of volume. Can be 'standard', 'gp2', 'io1', 'sc1', or 'st1'. (Default: 'gp2')."
-  default     = "gp2"
+  description = "(Optional) The type of volume. Can be 'standard', 'gp2', 'gp3', 'io1', 'sc1', or 'st1'."
+  default     = "gp3"
 }
 
 variable "vpc_id" {
@@ -39,4 +39,15 @@ variable "instance_type" {
 variable "tags" {
   type        = map(string)
   description = "A mapping of tags to assign to the AWS resources."
+}
+
+variable "allowed_cidr_blocks" {
+  type        = list(string)
+  description = "CIDR blocks permitted to reach the bastion on port 22. The module intentionally requires this — prior versions defaulted to 0.0.0.0/0, which defeats the purpose of a jump host. Production callers should restrict to known egress IPs (office, VPN, NAT gateway, etc.). An empty list denies all SSH ingress."
+}
+
+variable "ami_id" {
+  type        = string
+  description = "(Optional) Explicit AMI ID to launch the bastion with. When null, the latest Amazon Linux 2023 AMI is used via a data source — convenient but means every new AMI Amazon publishes forces a plan-time replacement. Production callers should pin a specific AMI ID and bump it on their own cadence."
+  default     = null
 }


### PR DESCRIPTION
## Summary

Takes the module from \"convenient-but-insecure default\" to \"safe to stand up in production without further hardening.\" Every change below was motivated by a real issue in a downstream consumer (see velocigent.ai-infrastructure#34): the module as shipped in v3.0.1 required each caller to either accept public-internet SSH, patch IMDSv1 drift by hand, or fork the module to add a `security_group_id` output so cross-resource rules could be composed correctly.

Target as **v4.0.0** — contains breaking changes.

## Breaking changes

### `allowed_cidr_blocks` is now a required input

The SG ingress rule no longer defaults to `0.0.0.0/0`. Callers must supply a CIDR list. A bastion reachable from the public internet on port 22 defeats the purpose of a jump host — the old default made it too easy to stand up an exposed SSH endpoint by accident.

**Migration:** add
\`\`\`hcl
allowed_cidr_blocks = [\"<office-or-vpn-cidr>/32\", ...]
\`\`\`
to every caller.

### AMI default is Amazon Linux 2023 (was Amazon Linux 2)

The `amazon-linux-2` data source targeting `amzn2-ami-hvm-*-x86_64-ebs` has been replaced with one targeting `al2023-ami-*-x86_64`. Existing instances will be replaced on next apply when `ami_id` is not set. Callers who need to stay on AL2 or pin a specific image should set `ami_id`.

### Volume defaults

| Var | Was | Now |
|---|---|---|
| `volume_size` | 15 | 30 GiB |
| `volume_type` | gp2 | gp3 |

gp3 is cheaper per GiB than gp2 at equivalent performance. 15 GiB was below AL2023's comfortable floor once logging and package updates are accounted for.

## New features

### `ami_id` input for explicit pinning

When null (default) the module resolves the latest AL2023 AMI via a data source — convenient for dev/test but produces perpetual plan drift in production as Amazon publishes new AMIs. Prod callers should pin an AMI ID and bump it on their own cadence.

### IMDSv2 required

`metadata_options { http_tokens = required }` is now set on the instance. This blocks IMDSv1-style unauthenticated metadata requests, which have been implicated in several well-known SSRF → credential-theft chains.

### AmazonSSMManagedInstanceCore attached to the bastion role

The instance is enrolled in SSM Session Manager as a break-glass fallback. If the SSH key is lost or port 22 is blocked, `aws ssm start-session --target <instance-id>` still works.

### New outputs for composition

| Output | Why |
|---|---|
| `security_group_id` | Lets the composing root module own cross-resource rules (e.g. \"permit bastion → Aurora 5432\") instead of the bastion module reaching into a sibling module's SG. This was the only way to solve the cross-module rule-ownership problem cleanly. |
| `instance_id` | Needed for SSM session targeting, Auto Scaling integration, and direct `aws ec2 describe-instances` runbooks. |
| `ssh_key_secret_arn` | For IAM policies that scope `secretsmanager:GetSecretValue` to the key. |
| `ssh_private_key_pem` (sensitive) | For automated tooling that needs to materialize the key without a Secrets Manager round trip (CI tunneling, terratest-style integration checks). |

## Test plan

- [x] `terraform fmt -recursive -check` clean
- [x] `terraform validate` clean
- [x] `terraform test -test-directory=tests/unit` → **11 passed, 0 failed**
- [ ] Integration lane (manual dispatch): SSH reachability against a real instance — harness updated to pass a permissive `allowed_cidr_blocks` so the CI runner's SSH probe can reach the bastion.

## Unit-test coverage added

- SG ingress CIDRs come from the variable (not a module default)
- IMDSv2 `http_tokens = required` is set
- SSM managed-instance policy is attached to the role
- `ami_id` override wins over the data source when set