### PR TITLE
refactor: migrate to aws_vpc_security_group_{ingress,egress}_rule (v4.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The module is opinionated on security posture: SSH ingress is restricted by call
 
 ```hcl
 module "bastion" {
-  source  = "git::https://github.com/synapsestudios/terraform-aws-bastion-server.git?ref=v4.0.0"
+  source  = "git::https://github.com/synapsestudios/terraform-aws-bastion-server.git?ref=v4.1.0"
 
   namespace   = "prod-myapp"
   environment = "prod"
@@ -29,14 +29,13 @@ module "bastion" {
 # Cross-resource rules (e.g. letting the bastion reach a database SG) are
 # the composing root module's responsibility. Reference `module.bastion.security_group_id`
 # and attach them where both sides of the relationship are visible.
-resource "aws_security_group_rule" "bastion_to_db" {
-  type                     = "ingress"
-  from_port                = 5432
-  to_port                  = 5432
-  protocol                 = "tcp"
-  source_security_group_id = module.bastion.security_group_id
-  security_group_id        = module.aurora.security_group_id
-  description              = "PostgreSQL access from bastion"
+resource "aws_vpc_security_group_ingress_rule" "bastion_to_db" {
+  security_group_id            = module.aurora.security_group_id
+  referenced_security_group_id = module.bastion.security_group_id
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+  description                  = "PostgreSQL access from bastion"
 }
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -80,22 +80,26 @@ resource "aws_security_group" "this" {
   vpc_id      = var.vpc_id
   name        = "bastion-${var.namespace}"
   tags        = merge(local.default_tags, var.tags, { Name = "Bastion" })
+}
 
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = 6
-    cidr_blocks = var.allowed_cidr_blocks
-    description = "Allow SSH from authorized CIDRs."
-  }
+resource "aws_vpc_security_group_ingress_rule" "ssh" {
+  for_each = toset(var.allowed_cidr_blocks)
 
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-    description = "Allow outgoing traffic."
-  }
+  security_group_id = aws_security_group.this.id
+  cidr_ipv4         = each.value
+  from_port         = 22
+  to_port           = 22
+  ip_protocol       = "tcp"
+  description       = "Allow SSH from ${each.value}"
+  tags              = merge(local.default_tags, var.tags)
+}
+
+resource "aws_vpc_security_group_egress_rule" "all" {
+  security_group_id = aws_security_group.this.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+  description       = "Allow outgoing traffic."
+  tags              = merge(local.default_tags, var.tags)
 }
 
 resource "aws_iam_role" "this" {

--- a/tests/unit/module.tftest.hcl
+++ b/tests/unit/module.tftest.hcl
@@ -60,23 +60,23 @@ run "sg_ingress_ssh_only" {
   command = plan
 
   assert {
-    condition     = length(aws_security_group.this.ingress) == 1
-    error_message = "Security group should expose exactly one ingress rule"
+    condition     = length(keys(aws_vpc_security_group_ingress_rule.ssh)) == length(var.allowed_cidr_blocks)
+    error_message = "Should produce one ingress rule per allowed CIDR"
   }
 
   assert {
-    condition     = tolist(aws_security_group.this.ingress)[0].from_port == 22
-    error_message = "Ingress from_port should be 22"
+    condition     = alltrue([for r in values(aws_vpc_security_group_ingress_rule.ssh) : r.from_port == 22])
+    error_message = "All ingress rules should target port 22"
   }
 
   assert {
-    condition     = tolist(aws_security_group.this.ingress)[0].to_port == 22
-    error_message = "Ingress to_port should be 22"
+    condition     = alltrue([for r in values(aws_vpc_security_group_ingress_rule.ssh) : r.to_port == 22])
+    error_message = "All ingress rules should terminate at port 22"
   }
 
   assert {
-    condition     = tolist(aws_security_group.this.ingress)[0].protocol == "6"
-    error_message = "Ingress protocol should be tcp (6)"
+    condition     = alltrue([for r in values(aws_vpc_security_group_ingress_rule.ssh) : r.ip_protocol == "tcp"])
+    error_message = "All ingress rules should use tcp"
   }
 }
 
@@ -84,8 +84,22 @@ run "sg_ingress_cidrs_from_variable" {
   command = plan
 
   assert {
-    condition     = tolist(tolist(aws_security_group.this.ingress)[0].cidr_blocks) == var.allowed_cidr_blocks
-    error_message = "Ingress cidr_blocks should come from var.allowed_cidr_blocks, not a module default"
+    condition     = toset(keys(aws_vpc_security_group_ingress_rule.ssh)) == toset(var.allowed_cidr_blocks)
+    error_message = "Ingress rules must be keyed by var.allowed_cidr_blocks"
+  }
+}
+
+run "sg_egress_allow_all" {
+  command = plan
+
+  assert {
+    condition     = aws_vpc_security_group_egress_rule.all.cidr_ipv4 == "0.0.0.0/0"
+    error_message = "Egress should permit all IPv4"
+  }
+
+  assert {
+    condition     = aws_vpc_security_group_egress_rule.all.ip_protocol == "-1"
+    error_message = "Egress ip_protocol should be -1 (all)"
   }
 }
 
@@ -198,5 +212,27 @@ run "synapse_standard_tags" {
       aws_secretsmanager_secret.this.tags["ModuleVersion"] == "local",
     ])
     error_message = "Secrets Manager secret must apply Synapse standard tags"
+  }
+
+  assert {
+    condition = alltrue([
+      for r in values(aws_vpc_security_group_ingress_rule.ssh) : alltrue([
+        r.tags["Environment"] == var.environment,
+        r.tags["ProvisionedBy"] == "terraform",
+        r.tags["Module"] == "terraform-aws-bastion-server",
+        r.tags["ModuleVersion"] == "local",
+      ])
+    ])
+    error_message = "Ingress rule resources must apply Synapse standard tags"
+  }
+
+  assert {
+    condition = alltrue([
+      aws_vpc_security_group_egress_rule.all.tags["Environment"] == var.environment,
+      aws_vpc_security_group_egress_rule.all.tags["ProvisionedBy"] == "terraform",
+      aws_vpc_security_group_egress_rule.all.tags["Module"] == "terraform-aws-bastion-server",
+      aws_vpc_security_group_egress_rule.all.tags["ModuleVersion"] == "local",
+    ])
+    error_message = "Egress rule resource must apply Synapse standard tags"
   }
 }


### PR DESCRIPTION
## Summary

- Swap inline `ingress`/`egress` blocks on `aws_security_group.this` for standalone `aws_vpc_security_group_ingress_rule` (`for_each` over `allowed_cidr_blocks`) and `aws_vpc_security_group_egress_rule` resources.
- Unblocks downstream callers who want to attach rules to `module.bastion.security_group_id` using the current best-practice resource type without triggering the provider's mixed-style conflict warning.
- Release as v4.1.0. No caller-facing interface change (no variable or output edits).

## Why

v4.0.0 (#17) exposed `security_group_id` as a composition seam, but a caller using `aws_vpc_security_group_ingress_rule` against the bastion SG while the module manages rules via inline blocks hits the provider's documented conflict: *"rule conflicts, perpetual differences, and result in rules being overwritten."* This PR moves the module onto the same shape callers should be using.

## Upgrade impact

- State-shape change only. Callers do not modify their module block.
- `terraform plan` will show the inline rules being destroyed and new `aws_vpc_security_group_{ingress,egress}_rule` resources being created. Brief ingress gap on apply — acceptable for a bastion.
- README example updated from `aws_security_group_rule` (legacy) to `aws_vpc_security_group_ingress_rule` (current), matching the module's new shape.

Closes #18

## Test plan

- [x] `terraform test -test-directory=tests/unit` — 12/12 pass (includes rewritten `sg_ingress_ssh_only`, `sg_ingress_cidrs_from_variable`, new `sg_egress_allow_all`, extended `synapse_standard_tags`).
- [x] `terraform validate` clean, `terraform fmt -check` clean.
- [ ] `terraform test -test-directory=tests/integration` — real-AWS `ssh_reachable` end-to-end confirmation before tagging v4.1.0.